### PR TITLE
sepolicy: Split off /cache/recovery's permissions

### DIFF
--- a/sepolicy/file.te
+++ b/sepolicy/file.te
@@ -8,3 +8,6 @@ type theme_data_file, file_type, data_file_type;
 
 # Performance settings
 type sysfs_devices_system_iosched, file_type, sysfs_type;
+
+# Recovery's "cache"
+type recovery_cache_file, file_type, mlstrustedobject;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,5 +1,7 @@
 /cache/dalvik-cache(/.*)? u:object_r:dalvikcache_data_file:s0
 
+/cache/recovery(/.*)?     u:object_r:recovery_cache_file:s0
+
 # Auditd is a logging daemon. Put it into logd's context
 /system/bin/auditd        u:object_r:logd_exec:s0
 /data/misc/audit(/.*)?    u:object_r:auditd_log:s0

--- a/sepolicy/recovery.te
+++ b/sepolicy/recovery.te
@@ -35,4 +35,8 @@ allow recovery file_type:notdevfile_class_set { unlink getattr };
 allow recovery install_data_file:file create_file_perms;
 allow recovery system_data_file:file create;
 
+# /cache/recovery things: command and logs
+allow recovery recovery_cache_file:dir create_dir_perms;
+allow recovery recovery_cache_file:file create_file_perms;
+
 ')

--- a/sepolicy/system_app.te
+++ b/sepolicy/system_app.te
@@ -1,3 +1,7 @@
 # For performance settings
 allow system_app sysfs_devices_system_cpu:file rw_file_perms;
 allow system_app sysfs_devices_system_iosched:file rw_file_perms;
+
+# For the updaters
+allow system_app recovery_cache_file:dir {add_name rw_file_perms};
+allow system_app recovery_cache_file:file {create rw_file_perms};


### PR DESCRIPTION
/cache/recovery is used by 2 domains: recovery and updater apps. Separate
its perms from the rest of /cache and grant them to those 2 clients

Change-Id: Iacde60744c07423f9876c2f8e3da900543e38ddf